### PR TITLE
feat: deprecated clean command

### DIFF
--- a/src/cmd/clean.ts
+++ b/src/cmd/clean.ts
@@ -1,10 +1,12 @@
 import { cleanJs } from '../utils';
+import chalk from 'chalk';
 
 class CleanCommand implements SubCommand {
   description = 'Clean js file while it has the same name ts/tsx file';
 
   async run(_, { cwd }: SubCommandOption) {
     cleanJs(cwd);
+    console.info(chalk.red('\nWARNING: `ets clean` has been deprecated! Use `tsc -b -c` instead\n'));
   }
 }
 

--- a/src/cmd/clean.ts
+++ b/src/cmd/clean.ts
@@ -6,7 +6,7 @@ class CleanCommand implements SubCommand {
 
   async run(_, { cwd }: SubCommandOption) {
     cleanJs(cwd);
-    console.info(chalk.red('\nWARNING: `ets clean` has been deprecated! Use `tsc -b -c` instead\n'));
+    console.info(chalk.red('\nWARNING: `ets clean` has been deprecated! Use `tsc -b --clean` instead\n'));
   }
 }
 

--- a/src/register.ts
+++ b/src/register.ts
@@ -27,7 +27,7 @@ export default class Register {
 
     const watch = util.convertString(process.env.ETS_WATCH, process.env.NODE_ENV !== 'test');
     const clazz = this.tsHelperClazz;
-    const cwd = process.cwd();
+    const cwd = options?.cwd || process.cwd();
     const instance = new clazz({ watch, ...options });
 
     if (util.checkMaybeIsJsProj(cwd)) {

--- a/test/cmd/clean.test.ts
+++ b/test/cmd/clean.test.ts
@@ -28,6 +28,6 @@ describe('cmd/clean.test.ts', () => {
 
   it('should deprecated clean command without error', async () => {
     const stdout = await getOutput('clean', '-c', path.resolve(__dirname, '../fixtures/app9'));
-    console.info(stdout);
+    assert(stdout.includes('`ets clean` has been deprecated'));
   });
 });

--- a/test/cmd/clean.test.ts
+++ b/test/cmd/clean.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { triggerBin, tsc } from '../utils';
+import { triggerBin, getOutput, tsc } from '../utils';
 import assert = require('assert');
 
 describe('cmd/clean.test.ts', () => {
@@ -24,5 +24,10 @@ describe('cmd/clean.test.ts', () => {
     assert(!fs.existsSync(path.resolve(appPath, './testtsx.js')));
     assert(!fs.existsSync(path.resolve(appPath, './app/testtsx.js')));
     assert(!fs.existsSync(path.resolve(appPath, './app/app/testtsx.js')));
+  });
+
+  it('should deprecated clean command without error', async () => {
+    const stdout = await getOutput('clean', '-c', path.resolve(__dirname, '../fixtures/app9'));
+    console.info(stdout);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

现在 ts 官方已经有 `tsc -b --clean` 可以用于清理同名 js 文件了，ets clean 可以废弃了

##### Description of change
<!-- Provide a description of the change below this comment. -->
