### PR TITLE
fix: load the tsconfig extends with the specific extension name

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@eggjs/tsconfig": "^1.0.0",
+    "@tsconfig/node14": "^14.1.2",
     "@types/commander": "^2.12.2",
     "@types/del": "^3.0.0",
     "@types/globby": "^6.1.0",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -442,11 +442,13 @@ export function loadTsConfig(tsconfigPath: string): ts.CompilerOptions {
       path.resolve(tsconfigDirName, extendPattern),
       path.resolve(tsconfigDirName, `${extendPattern}.json`),
     ];
-
-    if (!path.extname(tsConfig.extends) && !extendPattern.startsWith('.') && !extendPattern.startsWith('/')) {
+    const isExtendFromNodeModules = !extendPattern.startsWith('.') && !extendPattern.startsWith('/');
+    if (isExtendFromNodeModules) {
+      const DEFAULT_TS_CONFIG_FILE_NAME = 'tsconfig.json';
+      const extendTsConfigPath = !path.extname(extendPattern) ? DEFAULT_TS_CONFIG_FILE_NAME : '';
       maybeRealExtendPath.push(
-        path.resolve(tsconfigDirName, 'node_modules', extendPattern, 'tsconfig.json'),
-        path.resolve(process.cwd(), 'node_modules', extendPattern, 'tsconfig.json'),
+        path.resolve(tsconfigDirName, 'node_modules', extendPattern, extendTsConfigPath),
+        path.resolve(process.cwd(), 'node_modules', extendPattern, extendTsConfigPath),
       );
     }
 

--- a/test/fixtures/test-tsconfig/tsconfig.node.json
+++ b/test/fixtures/test-tsconfig/tsconfig.node.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/node14/tsconfig.json"
+}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -220,5 +220,10 @@ describe('utils.test.ts', () => {
     const tsConfig2 = utils.loadTsConfig(path.resolve(__dirname, './fixtures/test-tsconfig/tsconfig.json'));
     assert(tsConfig2);
     assert(tsConfig2.skipLibCheck);
+
+    const tsConfig3 = utils.loadTsConfig(path.resolve(__dirname, './fixtures/test-tsconfig/tsconfig.node.json'));
+    assert(tsConfig3);
+    assert(tsConfig3.strict);
+    assert(tsConfig3.skipLibCheck);
   });
 });


### PR DESCRIPTION
support load the tsconfig extends like that The following code is shown

``` json
{
  "extends": "@tsconfig/node16/tsconfig.json",
  "compilerOptions": {
    "module": "CommonJS",
    "declaration": true,
  },
}

```
support for version@2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved handling of extending TypeScript configuration files, specifically for extension patterns from node_modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->